### PR TITLE
Initial 1.20.5 Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ artifact = particle
 description = ParticleLib
 author = GeorgeV22
 version = 1.1.0-alpha.4
-mcVersion = 1.20
+mcVersion = 1.20.5

--- a/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
+++ b/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
@@ -101,7 +101,7 @@ public final class ReflectionUtils {
         int dashIndex = bukkitVersion.indexOf("-");
         MINECRAFT_VERSION = Double.parseDouble(bukkitVersion.substring(2, dashIndex > -1 ? bukkitVersion.indexOf("-") : bukkitVersion.length()));
         NET_MINECRAFT_SERVER_PACKAGE_PATH = "net.minecraft" + (MINECRAFT_VERSION < 17 ? ".server." + version : "");
-        CRAFT_BUKKIT_PACKAGE_PATH = "org.bukkit.craftbukkit." + version;
+        CRAFT_BUKKIT_PACKAGE_PATH = MINECRAFT_VERSION >= 20.4 ? "org.bukkit.craftbukkit" : "org.bukkit.craftbukkit." + version;
         plugin = readDeclaredField(PLUGIN_CLASS_LOADER_PLUGIN_FIELD, ReflectionUtils.class.getClassLoader());
         PLAYER_CONNECTION_CACHE = new PlayerConnectionCache();
         try {

--- a/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
+++ b/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
@@ -101,7 +101,7 @@ public final class ReflectionUtils {
         int dashIndex = bukkitVersion.indexOf("-");
         MINECRAFT_VERSION = Double.parseDouble(bukkitVersion.substring(2, dashIndex > -1 ? bukkitVersion.indexOf("-") : bukkitVersion.length()));
         NET_MINECRAFT_SERVER_PACKAGE_PATH = "net.minecraft" + (MINECRAFT_VERSION < 17 ? ".server." + version : "");
-        CRAFT_BUKKIT_PACKAGE_PATH = MINECRAFT_VERSION >= 20.4 ? "org.bukkit.craftbukkit" : "org.bukkit.craftbukkit." + version;
+        CRAFT_BUKKIT_PACKAGE_PATH = MINECRAFT_VERSION > 20.4 ? "org.bukkit.craftbukkit" : "org.bukkit.craftbukkit." + version;
         plugin = readDeclaredField(PLUGIN_CLASS_LOADER_PLUGIN_FIELD, ReflectionUtils.class.getClassLoader());
         PLAYER_CONNECTION_CACHE = new PlayerConnectionCache();
         try {


### PR DESCRIPTION
This PR adds initial 1.20.5 support. Most notably, adding support for Paper's removal of the CraftBukkit package relocation. Paper 1.20.4/5 no longer relocate CraftBukkit packages based on NMS version.