### PR TITLE
1.21 Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ artifact = particle
 description = ParticleLib
 author = GeorgeV22
 version = 1.1.0
-mcVersion = 1.20.6
+mcVersion = 1.21

--- a/src/main/java/com/georgev22/particle/ParticleConstants.java
+++ b/src/main/java/com/georgev22/particle/ParticleConstants.java
@@ -194,6 +194,10 @@ public final class ParticleConstants {
      * Represents the CraftItemStack#asNMSCopy(); method.
      */
     public static final Method CRAFT_ITEM_STACK_AS_NMS_COPY_METHOD;
+    /**
+     * Represents the MinecraftKey#parse(); method.
+     */
+    public static final Method MINECRAFT_KEY_METHOD;
 
     /* ---------------- Fields ---------------- */
 
@@ -318,6 +322,7 @@ public final class ParticleConstants {
         CRAFT_PLAYER_GET_HANDLE_METHOD = getMethodOrNull(CRAFT_PLAYER_CLASS, "getHandle");
         BLOCK_GET_BLOCK_DATA_METHOD = getMappedMethod(BLOCK_CLASS, "Block.getBlockData");
         CRAFT_ITEM_STACK_AS_NMS_COPY_METHOD = getMethodOrNull(CRAFT_ITEM_STACK_CLASS, "asNMSCopy", ItemStack.class);
+        MINECRAFT_KEY_METHOD = getMappedMethod(MINECRAFT_KEY_CLASS, "MinecraftKey.parse", String.class);
 
         // Fields
         ENTITY_PLAYER_PLAYER_CONNECTION_FIELD = getMappedField(ENTITY_PLAYER_CLASS, "EntityPlayer.playerConnection", false);

--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -81,6 +81,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #DRIPPING_HONEY}</li>
  * <li>{@link #DRIPPING_OBSIDIAN_TEAR}</li>
  * <li>{@link #DUST_COLOR_TRANSITION}</li>
+ * <li>{@link #DUST_PILLAR}</li>
  * <li>{@link #DUST_PLUME}</li>
  * <li>{@link #ELECTRIC_SPARK}</li>
  * <li>{@link #ENCHANTMENT_TABLE}</li>
@@ -479,6 +480,19 @@ public enum ParticleEffect {
      * </ul>
      */
     DUST_COLOR_TRANSITION(version -> version < 17 ? "NONE" : "dust_color_transition", COLORABLE, DUST),
+    /**
+     * In vanilla, this particle is displayed when a player hits an
+     * entity with a Mace smash attack.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: Little piece of a texture.</li>
+     * <li>Speed value: Influences the velocity at which the particle flies off.</li>
+     * <li>Extra:<ul>
+     * <li> This particle needs a block texture in order to work.</li></ul></li>
+     * </ul>
+     */
+    DUST_PILLAR(version -> version < 20.5 ? "NONE" : "dust_pillar", DIRECTIONAL, REQUIRES_BLOCK),
     /**
      * In vanilla, this particle is shown when adding items to decorated pots.
      * <p>

--- a/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
+++ b/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
@@ -425,6 +425,10 @@ public final class ReflectionUtils {
         if (key == null)
             return null;
         try {
+            // Minecraft removed the MinecraftKey constructor in 1.21 in favor of a static method.
+            if (MINECRAFT_VERSION > 20.6) {
+                return ParticleConstants.MINECRAFT_KEY_METHOD.invoke(null, key);
+            }
             return ParticleConstants.MINECRAFT_KEY_CONSTRUCTOR.newInstance(key);
         } catch (Exception ex) {
             return null;

--- a/src/main/resources/mappings.json
+++ b/src/main/resources/mappings.json
@@ -404,6 +404,10 @@
       {
         "from": 20,
         "value": "n"
+      },
+      {
+        "from": 21,
+        "value": "o"
       }
     ]
   },
@@ -518,6 +522,10 @@
       {
         "from": 20.3,
         "value": "j"
+      },
+      {
+        "from": 21,
+        "value": "i"
       }
     ]
   },
@@ -533,6 +541,17 @@
       {
         "from": 20.3,
         "value": "e"
+      }
+    ]
+  },
+  {
+    "name": "MinecraftKey.parse",
+    "min": 21,
+    "max": 99,
+    "mappings": [
+      {
+        "from": 21,
+        "value": "a"
       }
     ]
   }


### PR DESCRIPTION
This PR adds 1.21 support and adds a missing particle that was introduced as a 1.21 experimental particle. 

Tested server versions: 1.21, 1.20.6, 1.20.4 and 1.8.8