### PR TITLE
feat: 1.21.3 and 1.21.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open an issue for a bug or feature request. **Don't** open an issue to ask for s
 
 ## Features
 
-* Multiversion support from 1.8 - 1.21 <sup>(All in one Jar)</sup>
+* Multiversion support from 1.8 - 1.21.4 <sup>(All in one Jar)</sup>
 * Colored particles
 * Particles with custom velocities
 * Particles with textures

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ artifact = particle
 description = ParticleLib
 author = GeorgeV22
 version = 1.2.0
-mcVersion = 1.21
+mcVersion = 1.21.4

--- a/src/main/java/com/georgev22/particle/ParticleConstants.java
+++ b/src/main/java/com/georgev22/particle/ParticleConstants.java
@@ -72,6 +72,10 @@ public final class ParticleConstants {
      */
     public static final Class VECTOR_3FA_CLASS;
     /**
+     * Represents the Vec3D class.
+     */
+    public static final Class VEC_3D_CLASS;
+    /**
      * Represents the abstract IRegistry class.
      */
     public static final Class REGISTRY_CLASS;
@@ -168,6 +172,11 @@ public final class ParticleConstants {
      */
     public static final Class PARTICLE_PARAM_SCULK_CHARGE_CLASS;
 
+    /**
+     * Represents the TrailParticleOption class.
+     */
+    public static final Class TRAIL_PARTICLE_OPTION_CLASS;
+
     /* ---------------- Methods ---------------- */
 
     /**
@@ -221,6 +230,10 @@ public final class ParticleConstants {
      */
     public static final Constructor VECTOR_3FA_CONSTRUCTOR;
     /**
+     * Represents the Vec3D constructor.
+     */
+    public static final Constructor VEC_3D_CONSTRUCTOR;
+    /**
      * Represents the BlockPosition constructor.
      */
     public static final Constructor BLOCK_POSITION_CONSTRUCTOR;
@@ -264,6 +277,10 @@ public final class ParticleConstants {
      * Represents the ParticleParamSculkCharge constructor.
      */
     public static final Constructor PARTICLE_PARAM_SCULK_CHARGE_CONSTRUCTOR;
+    /**
+     * Represents the TrailParticleOption constructor.
+     */
+    public static final Constructor TRAIL_PARTICLE_OPTION_CONSTRUCTOR;
 
 
     /* ---------------- Object constants ---------------- */
@@ -290,6 +307,7 @@ public final class ParticleConstants {
         PARTICLE_CLASS = getMappedClass("Particle");
         MINECRAFT_KEY_CLASS = getMappedClass("MinecraftKey");
         VECTOR_3FA_CLASS = version < 17 ? getNMSClass("Vector3f") : (version < 19.3 ? getClassSafe("com.mojang.math.Vector3fa") : getClassSafe("org.joml.Vector3f"));
+        VEC_3D_CLASS = getNMSClass("world.phys.Vec3D");
         REGISTRY_CLASS = getMappedClass("IRegistry");
         BUILT_IN_REGISTRIES_CLASS = getMappedClass("BuiltInRegistries");
         BLOCK_CLASS = getMappedClass("Block");
@@ -314,6 +332,7 @@ public final class ParticleConstants {
         PARTICLE_PARAM_VIBRATION_CLASS = getMappedClass("ParticleParamVibration");
         PARTICLE_PARAM_SHRIEK_CLASS = getMappedClass("ParticleParamShriek");
         PARTICLE_PARAM_SCULK_CHARGE_CLASS = getMappedClass("ParticleParamSculkCharge");
+        TRAIL_PARTICLE_OPTION_CLASS = getMappedClass("ParticleParamTargetColor");
 
         // Methods
         REGISTRY_GET_METHOD = getMappedMethod(REGISTRY_CLASS, "Registry.get", MINECRAFT_KEY_CLASS);
@@ -337,6 +356,7 @@ public final class ParticleConstants {
 
         MINECRAFT_KEY_CONSTRUCTOR = getConstructorOrNull(MINECRAFT_KEY_CLASS, String.class);
         VECTOR_3FA_CONSTRUCTOR = getConstructorOrNull(VECTOR_3FA_CLASS, float.class, float.class, float.class);
+        VEC_3D_CONSTRUCTOR = getConstructorOrNull(VEC_3D_CLASS, double.class, double.class, double.class);
         BLOCK_POSITION_CONSTRUCTOR = getConstructorOrNull(BLOCK_POSITION_CLASS, double.class, double.class, double.class);
         BLOCK_POSITION_SOURCE_CONSTRUCTOR = version < 17 ? null : getConstructorOrNull(BLOCK_POSITION_SOURCE_CLASS, BLOCK_POSITION_CLASS);
         if (version < 17)
@@ -352,10 +372,17 @@ public final class ParticleConstants {
             PARTICLE_PARAM_REDSTONE_CONSTRUCTOR = null;
         else if (version < 17)
             PARTICLE_PARAM_REDSTONE_CONSTRUCTOR = getConstructorOrNull(PARTICLE_PARAM_REDSTONE_CLASS, float.class, float.class, float.class, float.class);
-        else
+        else if (version < 21.3)
             PARTICLE_PARAM_REDSTONE_CONSTRUCTOR = getConstructorOrNull(PARTICLE_PARAM_REDSTONE_CLASS, VECTOR_3FA_CLASS, float.class);
+        else
+            PARTICLE_PARAM_REDSTONE_CONSTRUCTOR = getConstructorOrNull(PARTICLE_PARAM_REDSTONE_CLASS, int.class, float.class);
 
-        PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR = version < 17 ? null : getConstructorOrNull(PARTICLE_PARAM_DUST_COLOR_TRANSITION_CLASS, VECTOR_3FA_CLASS, VECTOR_3FA_CLASS, float.class);
+        PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR = version < 17
+                ? null
+                : (version < 21.3
+                    ? getConstructorOrNull(PARTICLE_PARAM_DUST_COLOR_TRANSITION_CLASS, VECTOR_3FA_CLASS, VECTOR_3FA_CLASS, float.class)
+                    : getConstructorOrNull(PARTICLE_PARAM_DUST_COLOR_TRANSITION_CLASS, int.class, int.class, float.class));
+
         PARTICLE_PARAM_BLOCK_CONSTRUCTOR = version < 13 ? null : getConstructorOrNull(PARTICLE_PARAM_BLOCK_CLASS, PARTICLE_CLASS, BLOCK_DATA_INTERFACE);
         PARTICLE_PARAM_ITEM_CONSTRUCTOR = version < 13 ? null : getConstructorOrNull(PARTICLE_PARAM_ITEM_CLASS, PARTICLE_CLASS, ITEM_STACK_CLASS);
         if (version < 17)
@@ -366,6 +393,11 @@ public final class ParticleConstants {
             PARTICLE_PARAM_VIBRATION_CONSTRUCTOR = getConstructorOrNull(PARTICLE_PARAM_VIBRATION_CLASS, POSITION_SOURCE_CLASS, int.class);
         PARTICLE_PARAM_SHRIEK_CONSTRUCTOR = version < 19 ? null : getConstructorOrNull(PARTICLE_PARAM_SHRIEK_CLASS, int.class);
         PARTICLE_PARAM_SCULK_CHARGE_CONSTRUCTOR = version < 19 ? null : getConstructorOrNull(PARTICLE_PARAM_SCULK_CHARGE_CLASS, float.class);
+        TRAIL_PARTICLE_OPTION_CONSTRUCTOR = version < 21.3
+                ? null
+                : (version < 21.4
+                    ? getConstructorOrNull(TRAIL_PARTICLE_OPTION_CLASS, VEC_3D_CLASS, int.class)
+                    : getConstructorOrNull(TRAIL_PARTICLE_OPTION_CLASS, VEC_3D_CLASS, int.class, int.class));
 
         // Constants
         PARTICLE_TYPE_REGISTRY = readField(

--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -24,10 +24,7 @@
 
 package com.georgev22.particle;
 
-import com.georgev22.particle.data.ParticleData;
-import com.georgev22.particle.data.SculkChargeData;
-import com.georgev22.particle.data.ShriekData;
-import com.georgev22.particle.data.VibrationData;
+import com.georgev22.particle.data.*;
 import com.georgev22.particle.data.color.*;
 import com.georgev22.particle.data.texture.BlockTexture;
 import com.georgev22.particle.data.texture.ItemTexture;
@@ -58,6 +55,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #ASH}</li>
  * <li>{@link #BARRIER}</li>
  * <li>{@link #BLOCK_CRACK}</li>
+ * <li>{@link #BLOCK_CRUMBLE}</li>
  * <li>{@link #BLOCK_DUST}</li>
  * <li>{@link #BUBBLE_COLUMN_UP}</li>
  * <li>{@link #BLOCK_MARKER}</li>
@@ -151,6 +149,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #SWEEP_ATTACK}</li>
  * <li>{@link #TOTEM}</li>
  * <li>{@link #TOWN_AURA}</li>
+ * <li>{@link #TRAIL}</li>
  * <li>{@link #TRIAL_OMEN}</li>
  * <li>{@link #TRIAL_SPAWNER_DETECTION}</li>
  * <li>{@link #TRIAL_SPAWNER_DETECTION_OMINOUS}</li>
@@ -215,6 +214,19 @@ public enum ParticleEffect {
      * </ul>
      */
     BLOCK_CRACK(version -> version < 8 ? "NONE" : (version < 13 ? "BLOCK_CRACK" : "block"), REQUIRES_BLOCK),
+    /**
+     * In vanilla, this particle is displayed when a player breaks
+     * a block or sprints. It's also displayed by iron golems while
+     * walking.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: Little piece of a texture.</li>
+     * <li>Speed value: Doesn't influence the particle.</li>
+     * <li>Extra: This particle needs a block texture in order to work.</li>
+     * </ul>
+     */
+    BLOCK_CRUMBLE(version -> version < 21.3 ? "NONE" : "block_crumble", REQUIRES_BLOCK),
     /**
      * In vanilla, this particle is displayed when an entity hits the ground
      * after falling. It's also displayed when an armorstand is broken.
@@ -1285,6 +1297,16 @@ public enum ParticleEffect {
      * </ul>
      */
     TOWN_AURA(version -> version < 8 ? "NONE" : (version < 13 ? "TOWN_AURA" : "mycelium"), DIRECTIONAL),
+    /**
+     * In vanilla, it is unknown how this particle spawns at this moment. This is an experimental particle.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: swirly-colored particle.</li>
+     * <li>Extra: The color and target of this particle can be set with {@link TrailData}.</li>
+     * </ul>
+     */
+    TRAIL(version -> version < 21.3 ? "NONE" : "trail"),
     /**
      * In vanilla, this particle is displayed by players and mobs with
      * the Trial Omen effect.

--- a/src/main/java/com/georgev22/particle/ParticlePacket.java
+++ b/src/main/java/com/georgev22/particle/ParticlePacket.java
@@ -24,10 +24,7 @@
 
 package com.georgev22.particle;
 
-import com.georgev22.particle.data.ParticleData;
-import com.georgev22.particle.data.SculkChargeData;
-import com.georgev22.particle.data.ShriekData;
-import com.georgev22.particle.data.VibrationData;
+import com.georgev22.particle.data.*;
 import com.georgev22.particle.data.color.DustData;
 import com.georgev22.particle.data.color.NoteColor;
 import com.georgev22.particle.data.color.ParticleColor;
@@ -267,6 +264,7 @@ public final class ParticlePacket {
                         || (data instanceof VibrationData && version >= 17)
                         || (data instanceof ShriekData && version >= 19)
                         || (data instanceof SculkChargeData && version >= 19)
+                        || (data instanceof TrailData && version >= 21.3)
                         || (data instanceof RegularColor && (version >= 17 && effect.hasProperty(PropertyType.DUST))))
                     return createGenericParticlePacket(location, nmsData);
                 if ((data instanceof BlockTexture && effect.hasProperty(PropertyType.REQUIRES_BLOCK))

--- a/src/main/java/com/georgev22/particle/data/TrailData.java
+++ b/src/main/java/com/georgev22/particle/data/TrailData.java
@@ -1,0 +1,114 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 ByteZ1337
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.georgev22.particle.data;
+
+import com.georgev22.particle.ParticleConstants;
+import com.georgev22.particle.ParticleEffect;
+import com.georgev22.particle.utils.ReflectionUtils;
+import lombok.Getter;
+import org.bukkit.Location;
+
+import java.awt.*;
+
+/**
+ * This class holds all data that is needed by the client to display a {@link ParticleEffect#TRAIL}
+ * particle. The required information is: The target {@link Location}, and the color of the particle, and the
+ * duration of the particle.
+ * <p>
+ * Minecraft only supports full block coordinates for the start and destination location. So any
+ * particle will spawn at the center of a block
+ *
+ * @author Nicholas V
+ * @see ParticleEffect#TRAIL
+ */
+@Getter
+public final class TrailData extends ParticleData {
+
+    /**
+     * The target of the particles to be displayed.
+     */
+    private final Location target;
+
+    /**
+     * The color of the particle.
+     */
+    private final Color color;
+
+    /**
+     * The duration of the particle.
+     */
+    private final int duration;
+
+
+    /**
+     * Constructs a new {@link TrailData} instance.
+     *
+     * @param target The target of the particles to be displayed.
+     * @param color    The color of the particle.
+     */
+    public TrailData(Location target, Color color, int duration) {
+        this.target = target;
+        this.color = color;
+        this.duration = duration;
+    }
+
+    /**
+     * Constructs a new {@link TrailData} instance.
+     *
+     * @param target The target of the particles to be displayed.
+     * @param color    The color of the particle.
+     */
+    public TrailData(Location target, Color color) {
+        this.target = target;
+        this.color = color;
+        duration = -1;
+    }
+
+    /**
+     * Creates a new TrailParticleOption instance with the data of the current {@link TrailData} instance.
+     * <p>
+     * Please note that this class is not supported in any versions before 1.21.3 and could lead to errors
+     * if used in legacy versions. Additionally, this class is called TargetColorParticleOption in version 1.21.3
+     * and TrailParticleOption in version 1.21.4 and above.
+     *
+     * @return a new TrailDataParticleOption instance with the data of the current {@link TrailData} instance.
+     */
+    @Override
+    public Object toNMSData() {
+        if (ReflectionUtils.MINECRAFT_VERSION < 21.3 || getEffect() != ParticleEffect.TRAIL)
+            return null;
+        try {
+            Object vec3D = ReflectionUtils.createVec3D(target.getX(), target.getY(), target.getZ());
+
+            if (ReflectionUtils.MINECRAFT_VERSION < 21.4) {
+                return ParticleConstants.TRAIL_PARTICLE_OPTION_CONSTRUCTOR.newInstance(vec3D, color.getRGB());
+            }
+            return ParticleConstants.TRAIL_PARTICLE_OPTION_CONSTRUCTOR.newInstance(vec3D, color.getRGB(), duration);
+
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/georgev22/particle/data/color/DustColorTransitionData.java
+++ b/src/main/java/com/georgev22/particle/data/color/DustColorTransitionData.java
@@ -134,12 +134,23 @@ public final class DustColorTransitionData extends DustData {
     public Object toNMSData() {
         if (ReflectionUtils.MINECRAFT_VERSION < 17 || getEffect() != ParticleEffect.DUST_COLOR_TRANSITION)
             return null;
-        Object fadeStart = ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue());
-        Object fadeEnd = ReflectionUtils.createVector3fa(getFadeRed(), getFadeGreen(), getFadeBlue());
-        try {
-            return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(fadeStart, fadeEnd, getSize());
-        } catch (Exception ex) {
-            return null;
+        if (ReflectionUtils.MINECRAFT_VERSION < 21.3) {
+            Object fadeStart = ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue());
+            Object fadeEnd = ReflectionUtils.createVector3fa(getFadeRed(), getFadeGreen(), getFadeBlue());
+            try {
+                return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(fadeStart, fadeEnd, getSize());
+            } catch (Exception ex) {
+                return null;
+            }
+        } else {
+            Color fadeStart = new Color(getRed(), getGreen(), getBlue());
+            Color fadeEnd = new Color(getFadeRed(), getFadeGreen(), getFadeBlue());
+
+            try {
+                return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(fadeStart.getRGB(), fadeEnd.getRGB(), getSize());
+            } catch (Exception ex) {
+                return null;
+            }
         }
     }
 }

--- a/src/main/java/com/georgev22/particle/data/color/DustData.java
+++ b/src/main/java/com/georgev22/particle/data/color/DustData.java
@@ -111,11 +111,16 @@ public class DustData extends RegularColor {
                 return new int[0];
             else if (ReflectionUtils.MINECRAFT_VERSION < 17 && getEffect() == ParticleEffect.REDSTONE)
                 return ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(getRed(), getGreen(), getBlue(), getSize());
-            else if (ReflectionUtils.MINECRAFT_VERSION >= 17) {
+            else if (ReflectionUtils.MINECRAFT_VERSION >= 17 && ReflectionUtils.MINECRAFT_VERSION < 21.3) {
                 Object colorVector = ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue());
                 return getEffect() == ParticleEffect.REDSTONE
                         ? ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(colorVector, getSize())
                         : ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(colorVector, colorVector, getSize());
+            } else if (ReflectionUtils.MINECRAFT_VERSION >= 21.3) {
+                Color color = new Color(getRed(), getGreen(), getBlue());
+                return getEffect() == ParticleEffect.REDSTONE
+                        ? ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(color.getRGB(), getSize())
+                        : ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(color.getRGB(), color.getRGB(), getSize());
             }
         } catch (Exception ignored) {
         }

--- a/src/main/java/com/georgev22/particle/data/color/RegularColor.java
+++ b/src/main/java/com/georgev22/particle/data/color/RegularColor.java
@@ -152,11 +152,19 @@ public class RegularColor extends ParticleColor {
             if (getEffect() == ParticleEffect.REDSTONE)
                 return ReflectionUtils.MINECRAFT_VERSION < 17
                         ? ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(getRed(), getGreen(), getBlue(), 1f)
-                        : ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue()), 1f);
+                        : (ReflectionUtils.MINECRAFT_VERSION < 21.3
+                            ? ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue()), 1f)
+                            : ParticleConstants.PARTICLE_PARAM_REDSTONE_CONSTRUCTOR.newInstance(new Color(getRed(), getGreen(), getBlue()).getRGB(), 1f));
             if (ReflectionUtils.MINECRAFT_VERSION < 17)
                 return null;
-            Object colorVector = ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue());
-            return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(colorVector, colorVector, 1f);
+            if (ReflectionUtils.MINECRAFT_VERSION < 21.3) {
+                Object colorVector = ReflectionUtils.createVector3fa(getRed(), getGreen(), getBlue());
+                return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(colorVector, colorVector, 1f);
+            }
+
+            Color color = new Color(getRed(), getGreen(), getBlue());
+            return ParticleConstants.PARTICLE_PARAM_DUST_COLOR_TRANSITION_CONSTRUCTOR.newInstance(color.getRGB(), color.getRGB(), 1f);
+
         } catch (Exception ex) {
             return null;
         }

--- a/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
+++ b/src/main/java/com/georgev22/particle/utils/ReflectionUtils.java
@@ -452,6 +452,22 @@ public final class ReflectionUtils {
     }
 
     /**
+     * Creates a new Vec3D instance.
+     *
+     * @param x x value of the vector.
+     * @param y y value of the vector.
+     * @param z z value of the vector.
+     * @return a Vec3D instance with the specified coordinates.
+     */
+    public static Object createVec3D(double x, double y, double z) {
+        try {
+            return ParticleConstants.VEC_3D_CONSTRUCTOR.newInstance(x, y, z);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    /**
      * Creates a new BlockPosition.
      *
      * @param location the {@link Location} of the block.

--- a/src/main/resources/mappings.json
+++ b/src/main/resources/mappings.json
@@ -343,6 +343,17 @@
     ]
   },
   {
+    "name": "ParticleParamTargetColor",
+    "min": 19,
+    "max": 99,
+    "mappings": [
+      {
+        "from": 21.3,
+        "value": "core.particles.TargetColorParticleOption"
+      }
+    ]
+  },
+  {
     "name": "Registry.get",
     "min": 13,
     "max": 99,
@@ -408,6 +419,10 @@
       {
         "from": 21,
         "value": "o"
+      },
+      {
+        "from": 21.3,
+        "value": "m"
       }
     ]
   },
@@ -427,6 +442,10 @@
       {
         "from": 20,
         "value": "c"
+      },
+      {
+        "from": 21.3,
+        "value": "f"
       }
     ]
   },


### PR DESCRIPTION
This PR adds full support for 1.21.3 and 1.21.4, including the new experimental particles. It is important to note that Paper currently does not have a stable release for 1.21.4, so testing has not been done on that server version yet; however, the mappings appear to be the same on 1.21.4. More robust testing for 1.21.4 will be completed once a stable build of Paper 1.21.4 has been released.

Tested Server Versions:
- 1.8.8
- 1.20.4
- 1.21.3

Below are the most notable changes.

### Version Update:
* Updated the Minecraft version from `1.21` to `1.21.4` in `gradle.properties`.

### New Particle Classes and Constructors:
* Added `VEC_3D_CLASS` and `TRAIL_PARTICLE_OPTION_CLASS` to `ParticleConstants.java`. [[1]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R74-R77) [[2]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R175-R179)
* Introduced new constructors for `Vec3D` and `TrailParticleOption` in `ParticleConstants.java`. [[1]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R232-R235) [[2]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R280-R283)
* Implemented the `createVec3D` method in `ReflectionUtils.java` to support the new `Vec3D` class.

### New Particle Effects:
* Added `TrailData` class to handle data for the new `Trail` particle effect.
* Updated `ParticleEffect.java` to include the `TRAIL` and `BLOCK_CRUMBLE` particle effects. [[1]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR152) [[2]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR1300-R1309)
* Modified `ParticlePacket.java` to support `TrailData`.

### Compatibility Adjustments:
* Adjusted constructors and methods in `DustData.java`, `DustColorTransitionData.java`, and `RegularColor.java` to support different constructor parameters, ensuring compatibility with versions 1.21.3 and above. [[1]](diffhunk://#diff-5ea688d54286d2b633e11308e7878a7b99c333aa1623d5189431868162962d0dR137-R154) [[2]](diffhunk://#diff-0bbed577d41eafe4f13855e7030ab88e745f7dfbcd5f265af14dd6df2f64a108L114-R123) [[3]](diffhunk://#diff-ae4568f167fdeb8db8e4eb56d14ef86fc538e0e0620ae08183c0bf2020c1f58bL155-R167)
