### PR TITLE
fix: account for all changes in 1.21.4

### DIFF
--- a/src/main/java/com/georgev22/particle/ParticleConstants.java
+++ b/src/main/java/com/georgev22/particle/ParticleConstants.java
@@ -332,7 +332,7 @@ public final class ParticleConstants {
         PARTICLE_PARAM_VIBRATION_CLASS = getMappedClass("ParticleParamVibration");
         PARTICLE_PARAM_SHRIEK_CLASS = getMappedClass("ParticleParamShriek");
         PARTICLE_PARAM_SCULK_CHARGE_CLASS = getMappedClass("ParticleParamSculkCharge");
-        TRAIL_PARTICLE_OPTION_CLASS = getMappedClass("ParticleParamTargetColor");
+        TRAIL_PARTICLE_OPTION_CLASS = getMappedClass("TrailParticleOption");
 
         // Methods
         REGISTRY_GET_METHOD = getMappedMethod(REGISTRY_CLASS, "Registry.get", MINECRAFT_KEY_CLASS);
@@ -351,8 +351,10 @@ public final class ParticleConstants {
             PACKET_PLAY_OUT_WORLD_PARTICLES_CONSTRUCTOR = getConstructorOrNull(PACKET_PLAY_OUT_WORLD_PARTICLES_CLASS, PARTICLE_ENUM, boolean.class, float.class, float.class, float.class, float.class, float.class, float.class, float.class, int.class, int[].class);
         else if (version < 15)
             PACKET_PLAY_OUT_WORLD_PARTICLES_CONSTRUCTOR = getConstructorOrNull(PACKET_PLAY_OUT_WORLD_PARTICLES_CLASS, PARTICLE_PARAM_CLASS, boolean.class, float.class, float.class, float.class, float.class, float.class, float.class, float.class, int.class);
-        else
+        else if (version < 21.4)
             PACKET_PLAY_OUT_WORLD_PARTICLES_CONSTRUCTOR = getConstructorOrNull(PACKET_PLAY_OUT_WORLD_PARTICLES_CLASS, PARTICLE_PARAM_CLASS, boolean.class, double.class, double.class, double.class, float.class, float.class, float.class, float.class, int.class);
+        else
+            PACKET_PLAY_OUT_WORLD_PARTICLES_CONSTRUCTOR = getConstructorOrNull(PACKET_PLAY_OUT_WORLD_PARTICLES_CLASS, PARTICLE_PARAM_CLASS, boolean.class, boolean.class, double.class, double.class, double.class, float.class, float.class, float.class, float.class, int.class);
 
         MINECRAFT_KEY_CONSTRUCTOR = getConstructorOrNull(MINECRAFT_KEY_CLASS, String.class);
         VECTOR_3FA_CONSTRUCTOR = getConstructorOrNull(VECTOR_3FA_CLASS, float.class, float.class, float.class);

--- a/src/main/java/com/georgev22/particle/ParticlePacket.java
+++ b/src/main/java/com/georgev22/particle/ParticlePacket.java
@@ -387,7 +387,10 @@ public final class ParticlePacket {
                 return packetConstructor.newInstance(param, true, locationX, locationY, locationZ, offsetX, offsetY, offsetZ, speed, amount, data);
             if (ReflectionUtils.MINECRAFT_VERSION < 15)
                 return packetConstructor.newInstance(param, true, locationX, locationY, locationZ, offsetX, offsetY, offsetZ, speed, amount);
-            return packetConstructor.newInstance(param, true, (double) locationX, (double) locationY, (double) locationZ, offsetX, offsetY, offsetZ, speed, amount);
+            if (ReflectionUtils.MINECRAFT_VERSION < 21.4) {
+                return packetConstructor.newInstance(param, true, (double) locationX, (double) locationY, (double) locationZ, offsetX, offsetY, offsetZ, speed, amount);
+            }
+            return packetConstructor.newInstance(param, true, true, (double) locationX, (double) locationY, (double) locationZ, offsetX, offsetY, offsetZ, speed, amount);
         } catch (Exception ex) {
             return null;
         }

--- a/src/main/resources/mappings.json
+++ b/src/main/resources/mappings.json
@@ -343,13 +343,17 @@
     ]
   },
   {
-    "name": "ParticleParamTargetColor",
+    "name": "TrailParticleOption",
     "min": 19,
     "max": 99,
     "mappings": [
       {
         "from": 21.3,
         "value": "core.particles.TargetColorParticleOption"
+      },
+      {
+        "from": 21.4,
+        "value": "core.particles.TrailParticleOption"
       }
     ]
   },


### PR DESCRIPTION
This PR fixes the last issues with 1.21.4. In PaperMC's dev builds, starting from build 20, their "hard-fork" is implemented. I don't foresee this causing any issues unless they mess up mappings since they are no longer a fork of Spigot. After testing on 1.21.4, I noticed a few protocol changes overlooked in the previous release. Below is a summary of those fixes. 

Class mappings:

* [`src/main/resources/mappings.json`](diffhunk://#diff-f74e83df2bf92db9db32944d0458c34bfaa27504789d09ec17626839dab0607aL346-R356): Updated the mapping for `ParticleParamTargetColor` to `TrailParticleOption` and added a new version-specific mapping for version 1.21.4 and above.

Packet constructors:

* [`src/main/java/com/georgev22/particle/ParticleConstants.java`](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976L354-R357): Added a new packet constructor for Minecraft versions 1.21.4 and above that includes an additional boolean parameter (two booleans: `boolean forceSpawn`, `boolean important`, both set to true).
* [`src/main/java/com/georgev22/particle/ParticlePacket.java`](diffhunk://#diff-da68641e55ee87b980c636f2b5997c30bd36aa1e0a143fa8c9214310a02d2116R390-R393): Updated the `createPacket` method to use the new packet constructor for versions 1.21.4 and above.