### PR TITLE
fix: update min version for TrailParticleOption and particle effect fixes

### DIFF
--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -115,6 +115,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #NAUTILUS}</li>
  * <li>{@link #NOTE}</li>
  * <li>{@link #OMINOUS_SPAWNING}</li>
+ * <li>{@link #PALE_OAK_LEAVES}</li>
  * <li>{@link #PORTAL}</li>
  * <li>{@link #RAID_OMEN}</li>
  * <li>{@link #REDSTONE}</li>

--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -904,6 +904,17 @@ public enum ParticleEffect {
      */
     OMINOUS_SPAWNING(version -> version < 20.5 ? "NONE" : "ominous_spawning", DIRECTIONAL),
     /**
+     * In vanilla, this particle is displayed falling off pale oak leaves
+     * in pale garden biomes.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: Gray leaf.</li>
+     * <li>Speed value: Doesn't influence the particle.</li>
+     * </ul>
+     */
+    PALE_OAK_LEAVES(version -> version < 21.4 ? "NONE" : "pale_oak_leaves", DIRECTIONAL),
+    /**
      * In vanilla, this particle is randomly displayed by nether
      * portal, endermen, ender chests, dragon eggs, endermites and end
      * gateway portals. It is also displayed when an ender pearl hits

--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -310,7 +310,7 @@ public enum ParticleEffect {
      * <li>Speed value: Doesn't influence the particle.</li>
      * </ul>
      */
-    CHERRY_LEAVES(version -> version < 19.4 ? "NONE" : version < 20 ? "falling_cherry_leaves" : "cherry_leaves"),
+    CHERRY_LEAVES(version -> version < 19.4 ? "NONE" : version < 20 ? "falling_cherry_leaves" : "cherry_leaves", DIRECTIONAL),
     /**
      * In vanilla, this particle is displayed when an entity dies.
      * <p>

--- a/src/main/resources/mappings.json
+++ b/src/main/resources/mappings.json
@@ -344,7 +344,7 @@
   },
   {
     "name": "TrailParticleOption",
-    "min": 19,
+    "min": 21.3,
     "max": 99,
     "mappings": [
       {


### PR DESCRIPTION
This PR includes updates to the `ParticleEffect` enum in the `ParticleEffect.java` file and changes to the `mappings.json` file to reflect new particle options and version mappings.

### Updates to `ParticleEffect` enum:

* Added the `DIRECTIONAL` property to the `CHERRY_LEAVES` particle effect.
* Introduced a new particle effect that was introduced in 1.21.4 named `PALE_OAK_LEAVES` with detailed information about its appearance and behaviour.

### Changes to `mappings.json`:

* Updated the minimum version for `TrailParticleOption` from 19 to 21.3.