### PR TITLE
feat: 1.21.5 - 1.21.10 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ artifact = particle
 description = ParticleLib
 author = GeorgeV22
 version = 1.3.2
-mcVersion = 1.21.4
+mcVersion = 1.21.10

--- a/src/main/java/com/georgev22/particle/ParticleBuilder.java
+++ b/src/main/java/com/georgev22/particle/ParticleBuilder.java
@@ -131,7 +131,7 @@ public class ParticleBuilder {
      */
     public ParticleBuilder(ParticleEffect particle) {
         this.particle = particle;
-        this.location = null;
+        location = null;
     }
 
 
@@ -238,9 +238,9 @@ public class ParticleBuilder {
      * @return the current instance to support building operations
      */
     public ParticleBuilder setOffset(Vector offset) {
-        this.offsetX = (float) offset.getX();
-        this.offsetY = (float) offset.getY();
-        this.offsetZ = (float) offset.getZ();
+        offsetX = (float) offset.getX();
+        offsetY = (float) offset.getY();
+        offsetZ = (float) offset.getZ();
         return this;
     }
 
@@ -339,8 +339,25 @@ public class ParticleBuilder {
      * @return the current instance to support building operations
      */
     public ParticleBuilder setColor(Color color) {
-        if (this.particle.hasProperty(PropertyType.COLORABLE))
-            this.particleData = new RegularColor(color);
+        if (particle.hasProperty(PropertyType.COLORABLE))
+            particleData = new RegularColor(color);
+        return this;
+    }
+
+    /**
+     * Sets the color of the particle. Note that particle
+     * needs the {@link PropertyType#COLORABLE} PropertyType
+     * to work.
+     *
+     * @param color the {@link Color} of the particle.
+     * @param alpha the alpha/brightness value of the color.
+     *              A value of 1f means full brightness. (Introduced in 1.20.5)
+     *              Using this parameter below 1.20.5 will have no effect.
+     * @return the current instance to support building operations
+     */
+    public ParticleBuilder setColor(Color color, float alpha) {
+        if (particle.hasProperty(PropertyType.COLORABLE))
+            particleData = new RegularColor(color, alpha);
         return this;
     }
 
@@ -353,10 +370,10 @@ public class ParticleBuilder {
     public Object toPacket() {
         if (location == null)
             throw new IllegalStateException("Missing location of particle.");
-        if (this.particleData != null)
-            this.particleData.setEffect(this.particle);
-        ParticlePacket packet = new ParticlePacket(this.particle, this.offsetX, this.offsetY, this.offsetZ, this.speed, this.amount, this.particleData);
-        return packet.createPacket(this.location);
+        if (particleData != null)
+            particleData.setEffect(particle);
+        ParticlePacket packet = new ParticlePacket(particle, offsetX, offsetY, offsetZ, speed, amount, particleData);
+        return packet.createPacket(location);
     }
 
     /**
@@ -374,7 +391,7 @@ public class ParticleBuilder {
      * @param players The players that should see the particle.
      */
     public void display(Player... players) {
-        this.display(Arrays.asList(players));
+        display(Arrays.asList(players));
     }
 
     /**

--- a/src/main/java/com/georgev22/particle/ParticleConstants.java
+++ b/src/main/java/com/georgev22/particle/ParticleConstants.java
@@ -177,6 +177,11 @@ public final class ParticleConstants {
      */
     public static final Class TRAIL_PARTICLE_OPTION_CLASS;
 
+    /**
+     * Represents the ColorParticleOption class.
+     */
+    public static final Class COLOR_PARTICLE_OPTION_CLASS;
+
     /* ---------------- Methods ---------------- */
 
     /**
@@ -207,6 +212,11 @@ public final class ParticleConstants {
      * Represents the MinecraftKey#parse(); method.
      */
     public static final Method MINECRAFT_KEY_METHOD;
+
+    /**
+     * Represents the ColorParticleOption#create(); method.
+     */
+    public static final Method COLOR_PARTICLE_OPTION_CREATE_METHOD;
 
     /* ---------------- Fields ---------------- */
 
@@ -282,6 +292,11 @@ public final class ParticleConstants {
      */
     public static final Constructor TRAIL_PARTICLE_OPTION_CONSTRUCTOR;
 
+    /**
+     * Represents the ColorParticleOption constructor.
+     */
+    public static final Constructor COLOR_PARTICLE_OPTION_CONSTRUCTOR;
+
 
     /* ---------------- Object constants ---------------- */
 
@@ -333,6 +348,7 @@ public final class ParticleConstants {
         PARTICLE_PARAM_SHRIEK_CLASS = getMappedClass("ParticleParamShriek");
         PARTICLE_PARAM_SCULK_CHARGE_CLASS = getMappedClass("ParticleParamSculkCharge");
         TRAIL_PARTICLE_OPTION_CLASS = getMappedClass("TrailParticleOption");
+        COLOR_PARTICLE_OPTION_CLASS = getMappedClass("ColorParticleOption");
 
         // Methods
         REGISTRY_GET_METHOD = getMappedMethod(REGISTRY_CLASS, "Registry.get", MINECRAFT_KEY_CLASS);
@@ -342,6 +358,10 @@ public final class ParticleConstants {
         BLOCK_GET_BLOCK_DATA_METHOD = getMappedMethod(BLOCK_CLASS, "Block.getBlockData");
         CRAFT_ITEM_STACK_AS_NMS_COPY_METHOD = getMethodOrNull(CRAFT_ITEM_STACK_CLASS, "asNMSCopy", ItemStack.class);
         MINECRAFT_KEY_METHOD = getMappedMethod(MINECRAFT_KEY_CLASS, "MinecraftKey.parse", String.class);
+        COLOR_PARTICLE_OPTION_CREATE_METHOD = version < 20.5 ? null : getMappedMethod(COLOR_PARTICLE_OPTION_CLASS, "ColorParticleOption.create", PARTICLE_CLASS, int.class);
+        if (COLOR_PARTICLE_OPTION_CREATE_METHOD != null) {
+            COLOR_PARTICLE_OPTION_CREATE_METHOD.setAccessible(true); // Make accessible in case it's not public
+        }
 
         // Fields
         ENTITY_PLAYER_PLAYER_CONNECTION_FIELD = getMappedField(ENTITY_PLAYER_CLASS, "EntityPlayer.playerConnection", false);
@@ -400,6 +420,10 @@ public final class ParticleConstants {
                 : (version < 21.4
                     ? getConstructorOrNull(TRAIL_PARTICLE_OPTION_CLASS, VEC_3D_CLASS, int.class)
                     : getConstructorOrNull(TRAIL_PARTICLE_OPTION_CLASS, VEC_3D_CLASS, int.class, int.class));
+
+        COLOR_PARTICLE_OPTION_CONSTRUCTOR = version < 20.5
+                ? null
+                : getConstructorOrNull(COLOR_PARTICLE_OPTION_CLASS, PARTICLE_CLASS, int.class);
 
         // Constants
         PARTICLE_TYPE_REGISTRY = readField(

--- a/src/main/java/com/georgev22/particle/ParticleEffect.java
+++ b/src/main/java/com/georgev22/particle/ParticleEffect.java
@@ -65,6 +65,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #CHERRY_LEAVES}</li>
  * <li>{@link #CLOUD}</li>
  * <li>{@link #COMPOSTER}</li>
+ * <li>{@link #COPPER_FIRE_FLAME}</li>
  * <li>{@link #CRIMSON_SPORE}</li>
  * <li>{@link #CRIT}</li>
  * <li>{@link #CRIT_MAGIC}</li>
@@ -94,6 +95,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #FALLING_NECTAR}</li>
  * <li>{@link #FALLING_OBSIDIAN_TEAR}</li>
  * <li>{@link #FALLING_SPORE_BLOSSOM}</li>
+ * <li>{@link #FIREFLY}</li>
  * <li>{@link #FIREWORKS_SPARK}</li>
  * <li>{@link #FLAME}</li>
  * <li>{@link #FLASH}</li>
@@ -148,6 +150,7 @@ import static com.georgev22.particle.PropertyType.*;
  * <li>{@link #SUSPENDED}</li>
  * <li>{@link #SUSPENDED_DEPTH}</li>
  * <li>{@link #SWEEP_ATTACK}</li>
+ * <li>{@link #TINTED_LEAVES}</li>
  * <li>{@link #TOTEM}</li>
  * <li>{@link #TOWN_AURA}</li>
  * <li>{@link #TRAIL}</li>
@@ -311,7 +314,7 @@ public enum ParticleEffect {
      * <li>Speed value: Doesn't influence the particle.</li>
      * </ul>
      */
-    CHERRY_LEAVES(version -> version < 19.4 ? "NONE" : version < 20 ? "falling_cherry_leaves" : "cherry_leaves", DIRECTIONAL),
+    CHERRY_LEAVES(version -> version < 19.4 ? "NONE" : (version < 20 ? "falling_cherry_leaves" : "cherry_leaves"), DIRECTIONAL),
     /**
      * In vanilla, this particle is displayed when an entity dies.
      * <p>
@@ -334,6 +337,17 @@ public enum ParticleEffect {
      * </ul>
      */
     COMPOSTER(version -> version < 14 ? "NONE" : "composter"),
+    /**
+     * In vanilla, this particle is randomly displayed by copper torches.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: Green flame.</li>
+     * <li>Speed value: Influences the velocity at which the particle flies off.</li>
+     * <li>Extra: The velocity of this particle can be set. The amount has to be 0.</li>
+     * </ul>
+     */
+    COPPER_FIRE_FLAME(version -> version < 21.9 ? "NONE" : "copper_fire_flame", DIRECTIONAL),
     /**
      * In vanilla, this particle is displayed in the crimson forest
      * nether biome.
@@ -665,6 +679,17 @@ public enum ParticleEffect {
      * </ul>
      */
     FALLING_SPORE_BLOSSOM(version -> version < 17 ? "NONE" : "falling_spore_blossom"),
+    /**
+     * In vanilla, this particle is displayed by firefly
+     * bushes.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: Flashing white square.</li>
+     * <li>Speed value: Influences the velocity at which the particle flies off.</li>
+     * </ul>
+     */
+    FIREFLY(version -> version < 21.5 ? "NONE" : "firefly", DIRECTIONAL),
     /**
      * In vanilla, this particle is displayed when a firework is
      * launched.
@@ -1194,7 +1219,7 @@ public enum ParticleEffect {
      * <li>Extra: offsetX, offsetY and offsetZ represent the rgb values of the particle. The amount has to be 0 or the color won't work.</li>
      * </ul>
      */
-    SPELL_MOB(version -> version < 8 ? "NONE" : (version < 13 ? "SPELL_MOB" : "entity_effect"), COLORABLE),
+    SPELL_MOB(version -> version < 8 ? "NONE" : (version < 13 ? "SPELL_MOB" : "entity_effect"), COLORABLE, REGULAR_COLOR),
     /**
      * In vanilla, this particle is displayed when an entity has
      * an active potion effect from a nearby beacon.
@@ -1206,7 +1231,7 @@ public enum ParticleEffect {
      * <li>Extra: offsetX, offsetY and offsetZ represent the rgb values of the particle. The amount has to be 0 or the color won't work.</li>
      * </ul>
      */
-    SPELL_MOB_AMBIENT(version -> version < 8 ? "NONE" : (version < 13 ? "SPELL_MOB_AMBIENT" : version > 20.4 ? "NONE" : "ambient_entity_effect"), COLORABLE),
+    SPELL_MOB_AMBIENT(version -> version < 8 ? "NONE" : (version < 13 ? "SPELL_MOB_AMBIENT" : (version < 20.5 ? "ambient_entity_effect" : "entity_effect")), COLORABLE, REGULAR_COLOR),
     /**
      * In vanilla, this particle is displayed randomly by witches.
      * <p>
@@ -1285,6 +1310,17 @@ public enum ParticleEffect {
      * </ul>
      */
     SWEEP_ATTACK(version -> version < 9 ? "NONE" : (version < 13 ? "SWEEP_ATTACK" : "sweep_attack"), RESIZEABLE),
+    /**
+     * In vanilla, this particle is displayed falling from trees.
+     * <p>
+     * <b>Information</b>:
+     * <ul>
+     * <li>Appearance: A colored leaf.</li>
+     * <li>Speed value: Represents the lightness of the color.</li>
+     * <li>Extra: offsetX, offsetY and offsetZ represent the rgb values of the particle. The amount has to be 0 or the color won't work.</li>
+     * </ul>
+     */
+    TINTED_LEAVES(version -> version < 21.5 ? "NONE" : "tinted_leaves", COLORABLE, REGULAR_COLOR),
     /**
      * In vanilla, this particle is displayed when a totem of
      * undying is used.
@@ -1613,7 +1649,8 @@ public enum ParticleEffect {
             return this == DUST_COLOR_TRANSITION;
         if (color instanceof DustData)
             return hasProperty(DUST);
-        return hasProperty(COLORABLE) && (this.equals(ParticleEffect.NOTE) ? color instanceof NoteColor : color instanceof RegularColor);
+
+        return hasProperty(COLORABLE) && (equals(NOTE) ? color instanceof NoteColor : color instanceof RegularColor);
     }
 
     /**

--- a/src/main/java/com/georgev22/particle/ParticlePacket.java
+++ b/src/main/java/com/georgev22/particle/ParticlePacket.java
@@ -375,11 +375,12 @@ public final class ParticlePacket {
 
         // Other colored particles
         if (ReflectionUtils.MINECRAFT_VERSION < 13 || effect != ParticleEffect.REDSTONE) {
-            float redDustGuard = (effect == ParticleEffect.REDSTONE && r == 0f ? Float.MIN_NORMAL : r);
             return createPacket(
                     effect.getNMSObject(),
-                    x, y, z,
-                    redDustGuard, g, b,
+                    x,y,z,
+                    (effect == ParticleEffect.REDSTONE && r == 0 ? Float.MIN_NORMAL : r),
+                    g,
+                    b,
                     1f,
                     0,
                     new int[0]

--- a/src/main/java/com/georgev22/particle/PropertyType.java
+++ b/src/main/java/com/georgev22/particle/PropertyType.java
@@ -40,6 +40,8 @@ import com.georgev22.particle.data.color.RegularColor;
  * <li>{@link #DIRECTIONAL}</li>
  * <li>{@link #COLORABLE}</li>
  * <li>{@link #RESIZEABLE}</li>
+ * <li>{@link #REGULAR_COLOR}</li>
+ * <li>{@link #DUST}</li>
  * </ul>
  *
  * @author ByteZ
@@ -87,6 +89,18 @@ public enum PropertyType {
      * Specifies that the size of the given particle can be changed in the offsetX parameter.
      */
     RESIZEABLE,
+    /**
+     * A regular color accepts ARGB values between 0-255. Please note that this
+     * {@link PropertyType} has been introduced to support the new colored particle classification
+     * in 1.20.5 called ColorParticleOption.
+     *
+     * @see RegularColor
+     * @see ParticleConstants#COLOR_PARTICLE_OPTION_CLASS
+     * @see ParticleEffect#SPELL_MOB
+     * @see ParticleEffect#SPELL_MOB_AMBIENT
+     * @see ParticleEffect#TINTED_LEAVES
+     */
+    REGULAR_COLOR,
     /**
      * A dust particle accepts a custom color and a custom size (between 0-4). Please note that
      * this {@link PropertyType} is not supported on pre 1.13 servers.

--- a/src/main/java/com/georgev22/particle/data/color/RegularColor.java
+++ b/src/main/java/com/georgev22/particle/data/color/RegularColor.java
@@ -203,7 +203,7 @@ public class RegularColor extends ParticleColor {
         try {
             // Handle non-Redstone / non-DustColorTransition particles
             if (getEffect() != ParticleEffect.REDSTONE && getEffect() != ParticleEffect.DUST_COLOR_TRANSITION) {
-                if (getEffect().hasProperty(PropertyType.REGULAR_COLOR)) {
+                if (getEffect().hasProperty(PropertyType.REGULAR_COLOR) && ReflectionUtils.MINECRAFT_VERSION >= 20.5) {
                     // Since 1.20.5 we can use ARGB for regular color particles, encoded in ColorParticleOption
                     return ParticleConstants.COLOR_PARTICLE_OPTION_CREATE_METHOD.invoke(null, getEffect().getNMSObject(), toARGB());
                 }

--- a/src/main/resources/mappings.json
+++ b/src/main/resources/mappings.json
@@ -450,6 +450,10 @@
       {
         "from": 21.3,
         "value": "f"
+      },
+      {
+        "from": 21.6,
+        "value": "g"
       }
     ]
   },
@@ -549,6 +553,10 @@
       {
         "from": 21,
         "value": "i"
+      },
+      {
+        "from": 21.9,
+        "value": "j"
       }
     ]
   },
@@ -574,6 +582,28 @@
     "mappings": [
       {
         "from": 21,
+        "value": "a"
+      }
+    ]
+  },
+  {
+    "name": "ColorParticleOption",
+    "min": 20.5,
+    "max": 99,
+    "mappings": [
+      {
+        "from": 20.5,
+        "value": "core.particles.ColorParticleOption"
+      }
+    ]
+  },
+  {
+    "name": "ColorParticleOption.create",
+    "min": 20.5,
+    "max": 99,
+    "mappings": [
+      {
+        "from": 20.5,
         "value": "a"
       }
     ]


### PR DESCRIPTION
This pull request updates the library to support new Minecraft particle effects introduced in version 1.21.10 and refactors code for improved clarity and consistency. The most important changes include adding support for new particles, updating the minimum supported Minecraft version, and introducing the new ColorParticleOption class, which was introduced in 1.20.5. This new class changes how coloured particles are encoded, now using ARGB values for certain particles that support setting brightness/alpha values. 

### Tested versions
- 1.8.8 (<1.13)
- 1.20.4 (<1.20.5)
- 1.21.8 (>1.20.5)
- 1.21.10 (>1.20.5)

### New particle support

* Added new particle effects: `COPPER_FIRE_FLAME`, `FIREFLY`, and `TINTED_LEAVES` to `ParticleEffect`, including documentation and version checks for each. [[1]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR68) [[2]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR98) [[3]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR153) [[4]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR340-R350) [[5]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR682-R692) [[6]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfR1313-R1323)
* Updated `SPELL_MOB` and `SPELL_MOB_AMBIENT` to use the `REGULAR_COLOR` property and adjusted version checks for ambient particles. Note: `SPELL_MOB_AMBIENT`[ has been removed as of 1.20.5](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/diff/src/main/java/org/bukkit/Particle.java?until=1113e50a392b36253c4ae458a6d3d73e04841111) and has been merged with `entity_effect`  [[1]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfL1197-R1222) [[2]](diffhunk://#diff-2c49a241853f79a58784262f2a048e67780e1cfa6766be0a0cf3c1bf54a22bbfL1209-R1234)
* Improved colour handling for particles, including the addition of an alpha parameter for colour brightness in `ParticleBuilder`.

### Minecraft version support

* Increased the minimum supported Minecraft version from `1.21.4` to `1.21.10` in `gradle.properties`.

### Internal API extensions

* Added new constants and reflection logic in `ParticleConstants` for `ColorParticleOption` class, methods, and constructors to support new colourable particle features. [[1]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R180-R184) [[2]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R216-R220) [[3]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R295-R299) [[4]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R351) [[5]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R361-R364) [[6]](diffhunk://#diff-21d9413e7af8ef5950db1a9f5dfaca96b2a1003fd833e79b756e0e4a597bf976R424-R427)